### PR TITLE
Add beta.gcr.io to list of supported GCR registries

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -56,6 +56,7 @@ var SupportedGCRRegistries = map[string]bool{
 	"bucket.gcr.io":     true,
 	"appengine.gcr.io":  true,
 	"gcr.kubernetes.io": true,
+	"beta.gcr.io":       true,
 }
 
 // GCROAuth2Endpoint describes the oauth2.Endpoint to be used when

--- a/credhelper/helper_unit_test.go
+++ b/credhelper/helper_unit_test.go
@@ -39,6 +39,7 @@ var gcrHosts = [...]string{
 	"bucket.gcr.io",
 	"appengine.gcr.io",
 	"gcr.kubernetes.io",
+	"beta.gcr.io",
 }
 var otherHosts = [...]string{"docker.io", "otherrepo.com"}
 


### PR DESCRIPTION
This hostname was used during the V1 to V2 transition and some customers are still using it to tag and pull images.