### PR TITLE
Fix error in  when no credential store file exists

### DIFF
--- a/cli/clear.go
+++ b/cli/clear.go
@@ -49,7 +49,7 @@ func (c *clearCmd) Execute(context.Context, *flag.FlagSet, ...interface{}) subco
 
 // ClearAll removes all credentials from the store (GCR or otherwise).
 func (c *clearCmd) ClearAll() error {
-	s, err := store.NewGCRCredStore()
+	s, err := store.DefaultGCRCredStore()
 	if err != nil {
 		return err
 	}

--- a/cli/configure-docker.go
+++ b/cli/configure-docker.go
@@ -162,7 +162,7 @@ func (c *dockerConfigCmd) setLegacyConfig(dockerConfig *configfile.ConfigFile, h
 	// Populate the AuthConfigs portion of the config.
 	// This allows 'docker build' work on Docker client versions 1.11 and 1.12,
 	// where AuthConfigs was
-	s, err := store.NewGCRCredStore()
+	s, err := store.DefaultGCRCredStore()
 	if err != nil {
 		printErrorln("Unable to read credentialStore: %v", err)
 	}

--- a/cli/dockerHelper.go
+++ b/cli/dockerHelper.go
@@ -32,7 +32,7 @@ type helperCmd struct {
 }
 
 func (*helperCmd) Execute(context.Context, *flag.FlagSet, ...interface{}) subcommands.ExitStatus {
-	store, err := store.NewGCRCredStore()
+	store, err := store.DefaultGCRCredStore()
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Failure: %v\n", err)
 		return subcommands.ExitFailure

--- a/cli/gcr-login.go
+++ b/cli/gcr-login.go
@@ -60,7 +60,7 @@ func (c *loginCmd) GCRLogin() error {
 	loginAgent := &auth.GCRLoginAgent{
 		AllowBrowser: !c.forbidBrowser,
 	}
-	s, err := store.NewGCRCredStore()
+	s, err := store.DefaultGCRCredStore()
 	if err != nil {
 		return err
 	}

--- a/cli/gcr-logout.go
+++ b/cli/gcr-logout.go
@@ -50,7 +50,7 @@ func (c *logoutCmd) Execute(context.Context, *flag.FlagSet, ...interface{}) subc
 // GCRLogout performs the actions necessary to remove any GCR credentials
 // from the credential store.
 func (*logoutCmd) GCRLogout() error {
-	s, err := store.NewGCRCredStore()
+	s, err := store.DefaultGCRCredStore()
 	if err != nil {
 		return err
 	}

--- a/credhelper/helper.go
+++ b/credhelper/helper.go
@@ -64,7 +64,7 @@ func NewGCRCredentialHelper(store store.GCRCredStore, userCfg config.UserConfig)
 // Delete lists all stored credentials and associated usernames.
 func (ch *gcrCredHelper) List() (map[string]string, error) {
 	all3pCreds, err := ch.store.AllThirdPartyCreds()
-	if err != nil {
+	if err != nil && !credentials.IsErrCredentialsNotFound(err) {
 		return nil, helperErr("could not retrieve 3p credentials", err)
 	}
 

--- a/credhelper/helper_integration_test.go
+++ b/credhelper/helper_integration_test.go
@@ -1,0 +1,135 @@
+// +build integration
+
+// Copyright 2017 Google, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package credhelper
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/GoogleCloudPlatform/docker-credential-gcr/config"
+	"github.com/GoogleCloudPlatform/docker-credential-gcr/store"
+	"github.com/docker/docker-credential-helpers/credentials"
+)
+
+var expectedGcrHosts = [...]string{
+	"gcr.io",
+	"us.gcr.io",
+	"eu.gcr.io",
+	"asia.gcr.io",
+	"b.gcr.io",
+	"bucket.gcr.io",
+	"appengine.gcr.io",
+	"gcr.kubernetes.io",
+	"beta.gcr.io",
+}
+
+var testCredStorePath = filepath.Clean("helper_test_cred_store.json")
+
+func TestMain(m *testing.M) {
+	err := cleanUp()
+	if err != nil {
+		panic(fmt.Sprintf("Unable to clean the test environment, test results cannot be trusted: %v", err))
+	}
+	exitCode := m.Run()
+
+	// be polite and clean up
+	cleanUp()
+	os.Exit(exitCode)
+}
+
+// cleanUp eliminates test artifacts.
+func cleanUp() error {
+	err := os.Remove(testCredStorePath)
+	if err != nil && !os.IsNotExist(err) {
+		return err
+	}
+	return nil
+}
+
+func TestList_NoCredFile(t *testing.T) {
+	err := cleanUp()
+	if err != nil {
+		t.Fatal("Could not clean the test environment.")
+	}
+	store := store.NewGCRCredStore(testCredStorePath)
+	userCfg, err := config.LoadUserConfig()
+	if err != nil {
+		t.Fatalf("Could not load user config file: %v", err)
+	}
+
+	helper := NewGCRCredentialHelper(store, userCfg)
+
+	creds, err := helper.List()
+
+	if err != nil {
+		t.Fatalf("Error listing credentials: %v", err)
+	}
+
+	if len(expectedGcrHosts) != len(creds) {
+		t.Fatalf("Expected %d credentials, got %d", len(expectedGcrHosts), len(creds))
+	}
+	for _, host := range expectedGcrHosts {
+		if username := creds["https://"+host]; username != "oauth2accesstoken" {
+			t.Errorf("Expected username to be %s for host %s, was %s", "oauth2accesstoken", host, username)
+		}
+	}
+}
+
+func TestList_CredFileExists(t *testing.T) {
+	err := cleanUp()
+	if err != nil {
+		t.Fatal("Could not clean the test environment.")
+	}
+
+	// Store some 3P creds in a credential file.
+	store := store.NewGCRCredStore(testCredStorePath)
+	expected3PRegistry := "https://coolreg.io"
+	expected3PUsername := "fancybear"
+	store.SetOtherCreds(&credentials.Credentials{
+		ServerURL: expected3PRegistry,
+		Username:  expected3PUsername,
+		Secret:    "спасиба",
+	})
+
+	userCfg, err := config.LoadUserConfig()
+	if err != nil {
+		t.Fatalf("Could not load user config file: %v", err)
+	}
+
+	helper := NewGCRCredentialHelper(store, userCfg)
+
+	creds, err := helper.List()
+
+	if err != nil {
+		t.Fatalf("Error listing credentials: %v", err)
+	}
+
+	if len(expectedGcrHosts)+1 != len(creds) {
+		t.Fatalf("Expected %d credentials, got %d", len(expectedGcrHosts), len(creds))
+	}
+	for _, host := range expectedGcrHosts {
+		if username := creds["https://"+host]; username != "oauth2accesstoken" {
+			t.Errorf("Expected username to be %s for host %s, was %s", "oauth2accesstoken", host, username)
+		}
+	}
+	if username := creds[expected3PRegistry]; username != expected3PUsername {
+		t.Fatal("Failed to include 3P credentials")
+	}
+
+}

--- a/store/store.go
+++ b/store/store.go
@@ -84,12 +84,19 @@ type credStore struct {
 	credentialPath string
 }
 
-// NewGCRCredStore returns a GCRCredStore which is backed by a file.
-func NewGCRCredStore() (GCRCredStore, error) {
+// DefaultGCRCredStore returns a GCRCredStore which is backed by a file.
+func DefaultGCRCredStore() (GCRCredStore, error) {
 	path, err := dockerCredentialPath()
 	return &credStore{
 		credentialPath: path,
 	}, err
+}
+
+// NewGCRCredStore returns a GCRCredStore which is backed by the given file.
+func NewGCRCredStore(path string) GCRCredStore {
+	return &credStore{
+		credentialPath: path,
+	}
 }
 
 // GetOtherCreds returns the stored credentials corresponding to the given


### PR DESCRIPTION
Manifests as "could not retrieve 3p credentials" during `docker build`

Change-Id: I981d1a4dc48862887b0063e7b47f4a5349d6b5b7
Signed-off-by: Jake Sanders <jsand@google.com>