### PR TITLE
force an auth token refresh when getting gcloud's access_token

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ By default, the helper searches for GCR credentials in the following order:
 	On other systems, $HOME/.config/gcloud/application_default_credentials.json.
 3. On Google App Engine it uses the appengine.AccessToken function.
 4. On Google Compute Engine and Google App Engine Managed VMs, it fetches credentials from the metadata server.
-5. From the gcloud SDK (i.e. the one printed via `gcloud config config-helper --format='value(credential.access_token)'`).
+5. From the gcloud SDK (i.e. the one printed via `gcloud config config-helper --force-auth-refresh --format='value(credential.access_token)'`).
 6. In the helper's private credential store (i.e. those stored via `docker-credential-gcr gcr-login`)
 
 However, the user may limit or re-order how the helper searches for GCR credentials using `docker-credential-gcr config --token-source`. Numbers 1-4 above are designated by the "env" source, 5 by "gcloud" and 6 by "store". Multiple sources are separated by commas, and the default is "env, gcloud, store".

--- a/credhelper/helper.go
+++ b/credhelper/helper.go
@@ -215,7 +215,7 @@ func tokenFromEnv() (string, error) {
 func tokenFromGcloudSDK(gcloudCmd cmd.Command) (string, error) {
 	// shelling out to gcloud is the only currently supported way of
 	// obtaining the gcloud access_token
-	stdout, err := gcloudCmd.Exec("config", "config-helper", "--format=value(credential.access_token)")
+	stdout, err := gcloudCmd.Exec("config", "config-helper", "--force-auth-refresh", "--format=value(credential.access_token)")
 	if err != nil {
 		return "", helperErr("`gcloud config config-helper` failed", err)
 	}

--- a/credhelper/helper_unit_test.go
+++ b/credhelper/helper_unit_test.go
@@ -571,7 +571,7 @@ func TestTokenFromGcloudSDK(t *testing.T) {
 	// This test is more-or-less tautological, but it's important to verify
 	// that gcloud is being queried in a supported way.
 	mockCmd := mock_cmd.NewMockCommand(mockCtrl)
-	mockCmd.EXPECT().Exec("config", "config-helper", "--format=value(credential.access_token)").Return([]uint8(gcloudCreds), nil)
+	mockCmd.EXPECT().Exec("config", "config-helper", "--force-auth-refresh", "--format=value(credential.access_token)").Return([]uint8(gcloudCreds), nil)
 
 	token, err := tokenFromGcloudSDK(mockCmd)
 


### PR DESCRIPTION
Signed-off-by: Jake Sanders <jsand@google.com>