### PR TITLE
1.4.1 -> 1.4.2

### DIFF
--- a/config/const.go
+++ b/config/const.go
@@ -40,7 +40,7 @@ const (
 	// MinorVersion is the credential helper's minor version number.
 	MinorVersion = 4
 	// PatchVersion is the credential helper's patch version number.
-	PatchVersion = 1
+	PatchVersion = 2
 )
 
 // SupportedGCRRegistries maps registry URLs to a bool representing whether


### PR DESCRIPTION
Change notes:
* Added k8s.gcr.io as a registry to authenticate for by default.
* The credential helper now refreshes the gcloud SDK's access token before returning it.

Signed-off-by: Jake Sanders <jsand@google.com>