### PR TITLE
update default & supported GCR registries

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ bazel*
 */test_credential_store.json
 **/testdata
 .idea
+*.iml

--- a/cli/configure-docker.go
+++ b/cli/configure-docker.go
@@ -124,7 +124,7 @@ func setConfig(dockerConfig *configfile.ConfigFile, helperSuffix string) subcomm
 		dockerConfig.CredentialHelpers = map[string]string{}
 	}
 
-	for registry := range config.SupportedGCRRegistries {
+	for registry := range config.DefaultGCRRegistries {
 		dockerConfig.CredentialHelpers[registry] = helperSuffix
 	}
 
@@ -186,12 +186,12 @@ func (c *dockerConfigCmd) setLegacyConfig(dockerConfig *configfile.ConfigFile, h
 }
 
 // Ensures that the AuthConfigs in the given ConfigFile are exactly the set
-// of config.SupportedGCRRegistries with the https scheme plus any 3p creds
+// of config.DefaultGCRRegistries with the https scheme plus any 3p creds
 // we have stored.
 // Returns true if the ConfigFile was modified, false otherwise.
 func setAuthConfigs(dockerConfig *configfile.ConfigFile, s store.GCRCredStore) bool {
 	newAuthconfigs := make(map[string]types.AuthConfig)
-	for registry := range config.SupportedGCRRegistries {
+	for registry := range config.DefaultGCRRegistries {
 		// 'auths' members take a scheme
 		registry = "https://" + registry
 		newAuthconfigs[registry] = types.AuthConfig{}

--- a/cli/configure-docker_unit_test.go
+++ b/cli/configure-docker_unit_test.go
@@ -30,12 +30,11 @@ import (
 
 func expectedAuthConfigs() map[string]types.AuthConfig {
 	return map[string]types.AuthConfig{
-		"https://gcr.io":           {},
-		"https://us.gcr.io":        {},
-		"https://eu.gcr.io":        {},
-		"https://asia.gcr.io":      {},
-		"https://appengine.gcr.io": {},
-		"https://k8s.gcr.io":       {},
+		"https://gcr.io":             {},
+		"https://us.gcr.io":          {},
+		"https://eu.gcr.io":          {},
+		"https://asia.gcr.io":        {},
+		"https://staging-k8s.gcr.io": {},
 	}
 }
 

--- a/config/const.go
+++ b/config/const.go
@@ -43,16 +43,13 @@ const (
 	PatchVersion = 2
 )
 
-// SupportedGCRRegistries maps registry URLs to a bool representing whether
-// or not the GCR credentials can be used to authenticate requests for that
-// repository.
-var SupportedGCRRegistries = map[string]bool{
-	"gcr.io":           true,
-	"us.gcr.io":        true,
-	"eu.gcr.io":        true,
-	"asia.gcr.io":      true,
-	"appengine.gcr.io": true,
-	"k8s.gcr.io":       true,
+// DefaultGCRRegistries contains the list of default registries to authenticate for.
+var DefaultGCRRegistries = map[string]bool{
+	"gcr.io":             true,
+	"us.gcr.io":          true,
+	"eu.gcr.io":          true,
+	"asia.gcr.io":        true,
+	"staging-k8s.gcr.io": true,
 }
 
 // SupportedGCRTokenSources maps config keys to plain english explanations for

--- a/credhelper/helper.go
+++ b/credhelper/helper.go
@@ -75,7 +75,6 @@ func (ch *gcrCredHelper) List() (map[string]string, error) {
 	}
 
 	for gcrRegistry := range config.DefaultGCRRegistries {
-		gcrRegistry = "https://" + gcrRegistry
 		resp[gcrRegistry] = gcrOAuth2Username
 	}
 

--- a/credhelper/helper.go
+++ b/credhelper/helper.go
@@ -250,7 +250,7 @@ func isAGCRHostname(serverURL string) bool {
 	if err != nil {
 		return false
 	}
-	return config.DefaultGCRRegistries[URL.Host] || config.DefaultGCRRegistries[URL.Hostname()] || config.DefaultGCRRegistries[serverURL] || strings.HasSuffix(URL.Hostname(), "gcr.io")
+	return config.DefaultGCRRegistries[URL.Host] || config.DefaultGCRRegistries[serverURL] || strings.HasSuffix(URL.Host, "gcr.io")
 }
 
 func helperErr(message string, err error) error {

--- a/credhelper/helper.go
+++ b/credhelper/helper.go
@@ -74,7 +74,7 @@ func (ch *gcrCredHelper) List() (map[string]string, error) {
 		resp[registry] = creds.Username
 	}
 
-	for gcrRegistry := range config.SupportedGCRRegistries {
+	for gcrRegistry := range config.DefaultGCRRegistries {
 		gcrRegistry = "https://" + gcrRegistry
 		resp[gcrRegistry] = gcrOAuth2Username
 	}
@@ -250,7 +250,7 @@ func isAGCRHostname(serverURL string) bool {
 	if err != nil {
 		return false
 	}
-	return config.SupportedGCRRegistries[URL.Host] || config.SupportedGCRRegistries[serverURL]
+	return config.DefaultGCRRegistries[URL.Host] || config.DefaultGCRRegistries[URL.Hostname()] || config.DefaultGCRRegistries[serverURL] || strings.HasSuffix(URL.Hostname(), "gcr.io")
 }
 
 func helperErr(message string, err error) error {

--- a/credhelper/helper_integration_test.go
+++ b/credhelper/helper_integration_test.go
@@ -32,8 +32,7 @@ var expectedGcrHosts = [...]string{
 	"us.gcr.io",
 	"eu.gcr.io",
 	"asia.gcr.io",
-	"appengine.gcr.io",
-	"k8s.gcr.io",
+	"staging-k8s.gcr.io",
 }
 
 var testCredStorePath = filepath.Clean("helper_test_cred_store.json")

--- a/credhelper/helper_integration_test.go
+++ b/credhelper/helper_integration_test.go
@@ -81,7 +81,7 @@ func TestList_NoCredFile(t *testing.T) {
 		t.Fatalf("Expected %d credentials, got %d", len(expectedGcrHosts), len(creds))
 	}
 	for _, host := range expectedGcrHosts {
-		if username := creds["https://"+host]; username != "oauth2accesstoken" {
+		if username := creds[host]; username != "oauth2accesstoken" {
 			t.Errorf("Expected username to be %s for host %s, was %s", "oauth2accesstoken", host, username)
 		}
 	}
@@ -120,7 +120,7 @@ func TestList_CredFileExists(t *testing.T) {
 		t.Fatalf("Expected %d credentials, got %d", len(expectedGcrHosts), len(creds))
 	}
 	for _, host := range expectedGcrHosts {
-		if username := creds["https://"+host]; username != "oauth2accesstoken" {
+		if username := creds[host]; username != "oauth2accesstoken" {
 			t.Errorf("Expected username to be %s for host %s, was %s", "oauth2accesstoken", host, username)
 		}
 	}

--- a/credhelper/helper_unit_test.go
+++ b/credhelper/helper_unit_test.go
@@ -63,7 +63,7 @@ func TestIsAGCRHostname(t *testing.T) {
 
 	// test for non-default GCR hosts
 	for _, host := range defaultGCRHosts {
-		if !isAGCRHostname("https://" + host) {
+		if !isAGCRHostname(host) {
 			t.Error("Expected to be detected as a GCR hostname: ", host)
 		}
 	}


### PR DESCRIPTION
This change prunes and updates the default GCR registries to authenticate for when using `configure-docker`, but also supports all `gcr.io` registries on `get` be default.  

Signed-off-by: Jake Sanders <jsand@google.com>