### PR TITLE
Use pure go to achieve static linkage

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -30,5 +30,6 @@ go_library(
 go_binary(
     name = "docker-credential-gcr",
     embed = [":go_default_library"],
+    pure = "on",
     visibility = ["//visibility:public"],
 )


### PR DESCRIPTION
Fixes https://github.com/GoogleCloudPlatform/docker-credential-gcr/issues/31

Signed-off-by: Jake Sanders <jsand@google.com>