### PR TITLE
Adds 'marketplace.gcr.io' as a default registry.

### DIFF
--- a/cli/configure-docker_unit_test.go
+++ b/cli/configure-docker_unit_test.go
@@ -33,6 +33,7 @@ func expectedAuthConfigs() map[string]types.AuthConfig {
 		"https://eu.gcr.io":          {},
 		"https://asia.gcr.io":        {},
 		"https://staging-k8s.gcr.io": {},
+		"https://marketplace.gcr.io": {},
 	}
 }
 

--- a/config/const.go
+++ b/config/const.go
@@ -53,6 +53,7 @@ var DefaultGCRRegistries = map[string]bool{
 	"eu.gcr.io":          true,
 	"asia.gcr.io":        true,
 	"staging-k8s.gcr.io": true,
+	"marketplace.gcr.io": true,
 }
 
 // SupportedGCRTokenSources maps config keys to plain english explanations for

--- a/credhelper/helper_integration_test.go
+++ b/credhelper/helper_integration_test.go
@@ -33,6 +33,7 @@ var expectedGcrHosts = [...]string{
 	"eu.gcr.io",
 	"asia.gcr.io",
 	"staging-k8s.gcr.io",
+	"marketplace.gcr.io",
 }
 
 var testCredStorePath = filepath.Clean("helper_test_cred_store.json")

--- a/credhelper/helper_unit_test.go
+++ b/credhelper/helper_unit_test.go
@@ -38,6 +38,7 @@ var defaultGCRHosts = [...]string{
 	"eu.gcr.io",
 	"asia.gcr.io",
 	"staging-k8s.gcr.io",
+	"marketplace.gcr.io",
 }
 var otherGCRHosts = [...]string{"appengine.gcr.io", "k8s.gcr.io"}
 var otherHosts = [...]string{"docker.io", "otherrepo.com"}


### PR DESCRIPTION
`marketplace.gcr.io` is an alias used by Google Cloud Launcher, and it requires authentication.