### PR TITLE
Escape a literal `*` in the Markdown

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ The helper implements the [Docker Credential Store](https://docs.docker.com/engi
 
 ### Building from Source
 
-The program in this repository is written with the Go programming language and built with `make`. These instructions assume that [**Go 1.7+**](https://golang.org/) and `make` are installed on a *nix system.
+The program in this repository is written with the Go programming language and built with `make`. These instructions assume that [**Go 1.7+**](https://golang.org/) and `make` are installed on a \*nix system.
 
 You can download the source code, compile the binary, and put it in your `$GOPATH` with `go get`.
 


### PR DESCRIPTION
In certain editors, the unescaped `*` could mark the beginning of Markdown boldface, and without a trailing `*`, syntax highlighting can become confused.