### PR TITLE
allow for users to define the set of registries in `configure-docker`

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,11 +76,17 @@ sudo mv ./bin/docker-credential-gcr /usr/bin/docker-credential-gcr
 
 ## Configuration and Usage
 
-* Configure the Docker CLI to use docker-credential-gcr as its credential store:
+* Configure the Docker CLI to use `docker-credential-gcr` as a credential helper for the default set of GCR registries:
 
 	```shell
 	docker-credential-gcr configure-docker
 	```
+
+  To speed up `docker build`s, you can instead configure a minimal set of registries:
+
+  ```shell
+  docker-credential-gcr configure-docker --registries="eu.gcr.io, marketplace.gcr.io"
+  ```
 
   * Alternatively, use the [manual configuration instructions](#manual-docker-client-configuration) below to configure your version of the Docker client.
 

--- a/config/const.go
+++ b/config/const.go
@@ -47,13 +47,12 @@ const (
 )
 
 // DefaultGCRRegistries contains the list of default registries to authenticate for.
-var DefaultGCRRegistries = map[string]bool{
-	"gcr.io":             true,
-	"us.gcr.io":          true,
-	"eu.gcr.io":          true,
-	"asia.gcr.io":        true,
-	"staging-k8s.gcr.io": true,
-	"marketplace.gcr.io": true,
+var DefaultGCRRegistries = [...]string{
+	"gcr.io",
+	"us.gcr.io",
+	"eu.gcr.io",
+	"asia.gcr.io",
+	"marketplace.gcr.io",
 }
 
 // SupportedGCRTokenSources maps config keys to plain english explanations for

--- a/credhelper/helper.go
+++ b/credhelper/helper.go
@@ -21,7 +21,6 @@ package credhelper
 import (
 	"errors"
 	"fmt"
-	"net/url"
 	"strings"
 
 	"github.com/GoogleCloudPlatform/docker-credential-gcr/config"
@@ -77,12 +76,7 @@ func (*gcrCredHelper) Delete(string) error {
 
 // Get returns the username and secret to use for a given registry server URL.
 func (ch *gcrCredHelper) Get(serverURL string) (string, string, error) {
-	// If this is a GCR hostname, return GCR's credentials.
-	if isAGCRHostname(serverURL) {
-		return ch.gcrCreds()
-	}
-
-	return "", "", credentials.NewErrCredentialsNotFound()
+	return ch.gcrCreds()
 }
 
 func (ch *gcrCredHelper) gcrCreds() (string, string, error) {
@@ -192,15 +186,6 @@ func tokenFromPrivateStore(store store.GCRCredStore) (string, error) {
 	}
 
 	return tok.AccessToken, nil
-}
-
-// isAGCRHostname returns true if the given hostname is one of GCR's
-func isAGCRHostname(serverURL string) bool {
-	URL, err := url.Parse(serverURL)
-	if err != nil {
-		return false
-	}
-	return config.DefaultGCRRegistries[URL.Host] || config.DefaultGCRRegistries[serverURL] || strings.HasSuffix(URL.Host, "gcr.io")
 }
 
 func helperErr(message string, err error) error {

--- a/credhelper/helper_unit_test.go
+++ b/credhelper/helper_unit_test.go
@@ -31,46 +31,15 @@ import (
 
 var expectedGCRUsername = fmt.Sprintf("_dcgcr_%d_%d_%d_token", config.MajorVersion, config.MinorVersion, config.PatchVersion)
 
-var defaultGCRHosts = [...]string{
+var testGCRHosts = [...]string{
 	"gcr.io",
 	"us.gcr.io",
 	"eu.gcr.io",
 	"asia.gcr.io",
 	"staging-k8s.gcr.io",
 	"marketplace.gcr.io",
-}
-var otherGCRHosts = [...]string{"appengine.gcr.io", "k8s.gcr.io"}
-var otherHosts = [...]string{"docker.io", "otherrepo.com"}
-
-func TestIsAGCRHostname(t *testing.T) {
-	t.Parallel()
-	// test for default GCR hosts
-	for _, host := range defaultGCRHosts {
-		if !isAGCRHostname(host) {
-			t.Error("Expected to be detected as a GCR hostname: ", host)
-		}
-	}
-
-	// test for default GCR hosts + scheme
-	for _, host := range otherGCRHosts {
-		if !isAGCRHostname("https://" + host) {
-			t.Error("Expected to be detected as a GCR hostname: ", "https://"+host)
-		}
-	}
-
-	// test for non-default GCR hosts
-	for _, host := range defaultGCRHosts {
-		if !isAGCRHostname(host) {
-			t.Error("Expected to be detected as a GCR hostname: ", host)
-		}
-	}
-
-	// test for non-GCR hosts
-	for _, host := range otherHosts {
-		if isAGCRHostname(host) {
-			t.Error("Expected to not be a GCR host: ", host)
-		}
-	}
+	"appengine.gcr.io",
+	"hypothetical-alias.gcr.io",
 }
 
 func TestGet_GCRCredentials(t *testing.T) {
@@ -98,7 +67,7 @@ func TestGet_GCRCredentials(t *testing.T) {
 	}
 
 	// Verify that all of GCR's hostnames return GCR's access token.
-	for _, host := range defaultGCRHosts {
+	for _, host := range testGCRHosts {
 		mockUserCfg.EXPECT().TokenSources().Return(config.DefaultTokenSources[:])
 		username, secret, err := tested.Get("https://" + host)
 		if err != nil {


### PR DESCRIPTION
* Let users specify the set of registries via `configure-docker --registries="foo.gcr.io, bar.gcr.io, baz.gcr.io"`
  * Default: `"gcr.io, us.gcr.io, eu.gcr.io, asia.gcr.io, marketplace.gcr.io"`

Fixes https://github.com/GoogleCloudPlatform/docker-credential-gcr/issues/49
