### PR TITLE
compute/metadata: unset ResponseHeaderTimeout

### DIFF
--- a/vendor/cloud.google.com/go/compute/metadata/metadata.go
+++ b/vendor/cloud.google.com/go/compute/metadata/metadata.go
@@ -68,7 +68,6 @@ var (
 				Timeout:   2 * time.Second,
 				KeepAlive: 30 * time.Second,
 			}).Dial,
-			ResponseHeaderTimeout: 2 * time.Second,
 		},
 	}}
 	subscribeClient = &Client{hc: &http.Client{


### PR DESCRIPTION
workload identity in gke credentials roundtrip is longer than 2 seconds when under load - this timeout causes gcr auth to fail frequently.

see upstream commit tagged in version v.0.53.0 https://github.com/googleapis/google-cloud-go/commit/fbf2f5121ef6008eb9b7e5c67aa0c9abfa7ac7fc

