### PR TITLE
version 2.0.0 -> 2.0.1

### DIFF
--- a/config/const.go
+++ b/config/const.go
@@ -43,7 +43,7 @@ const (
 	// MinorVersion is the credential helper's minor version number.
 	MinorVersion = 0
 	// PatchVersion is the credential helper's patch version number.
-	PatchVersion = 0
+	PatchVersion = 1
 )
 
 // DefaultGCRRegistries contains the list of default registries to authenticate for.


### PR DESCRIPTION
cut a new release to fix timeouts on GKE with Workload Identity enabled