### PR TITLE
Add --include-artifact-registry flag to configure-docker 

### DIFF
--- a/config/const.go
+++ b/config/const.go
@@ -55,6 +55,23 @@ var DefaultGCRRegistries = [...]string{
 	"marketplace.gcr.io",
 }
 
+// DefaultARRegistries contains the list of default registries for Artifact
+// Registry.  If the --include-artifact-registry flag is supplied then these
+// are added in addition to the GCR Registries.
+var DefaultARRegistries = [...]string{
+	"northamerica-northeast1-docker.pkg.dev", "us-central1-docker.pkg.dev",
+	"us-east1-docker.pkg.dev", "us-east4-docker.pkg.dev",
+	"us-west2-docker.pkg.dev", "us-west1-docker.pkg.dev",
+	"southamerica-east1-docker.pkg.dev", "europe-north1-docker.pkg.dev",
+	"europe-west1-docker.pkg.dev", "europe-west2-docker.pkg.dev",
+	"europe-west3-docker.pkg.dev", "europe-west4-docker.pkg.dev",
+	"europe-west6-docker.pkg.dev", "asia-east1-docker.pkg.dev",
+	"asia-east2-docker.pkg.dev", "asia-northeast1-docker.pkg.dev",
+	"asia-northeast2-docker.pkg.dev", "asia-south1-docker.pkg.dev",
+	"asia-southeast1-docker.pkg.dev", "australia-southeast1-docker.pkg.dev",
+	"asia-docker.pkg.dev", "europe-docker.pkg.dev", "us-docker.pkg.dev",
+}
+
 // SupportedGCRTokenSources maps config keys to plain english explanations for
 // where the helper should search for a GCR access token.
 var SupportedGCRTokenSources = map[string]string{


### PR DESCRIPTION
Add --include-artifact-registry flag to configure-docker to include all AR registries in the default case. Improved feedback messages when running the command.  This is intended to be used by tooling that needs to be configured to send tokens to any Artifact Registry region.

This will be used by services that can take an arbitrary image URL from GCR or AR and needs to be able to pull that image by supplying access tokens.  The service will run configure-docker --include-artifact-registry as part of setup to ensure that all AR regions are supported.

We will need to update the list of AR regions in this tool when more regions are turned up.