### PR TITLE
unix home directory - give precedence to $HOME

### DIFF
--- a/util/util.go
+++ b/util/util.go
@@ -38,10 +38,16 @@ func SdkConfigPath() (string, error) {
 	return filepath.Join(homeDir, ".config", "gcloud"), nil
 }
 
+// unixHomeDir returns the user's home directory.  Note that $HOME has
+// precedence over records in the password database since the credential helper
+// may be running under a different UID in a user namespace.
 func unixHomeDir() string {
-	usr, err := user.Current()
-	if err == nil {
+	homeDir := os.Getenv("HOME")
+	if homeDir != "" {
+		return homeDir
+	}
+	if usr, err := user.Current(); err == nil {
 		return usr.HomeDir
 	}
-	return os.Getenv("HOME")
+	return ""
 }


### PR DESCRIPTION
Give precedence to the $HOME environment variable of the password
database.  The credential helper may be running in a user namespace
where the database is likely tricked into looking up a wrong user
since the current UID is different.

Giving precedence to $HOME will fix an issue in Podman [1] where the
credential helper is erroring out with EPERMs since it uses the root's
home directory.

[1] https://lists.podman.io/archives/list/podman@lists.podman.io/thread/CZY7J34AZHXZOK34Y4JNNIOVR62N43XO/

Signed-off-by: Valentin Rothberg <rothberg@redhat.com>