### PR TITLE
Automate release with goreleaser

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,22 @@
+name: goreleaser
+
+on:
+  push:
+    tags: ["*"]
+
+jobs:
+  goreleaser:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Unshallow
+        run: git fetch --prune --unshallow
+      - uses: actions/setup-go@v1
+        with:
+          go-version: 1.16.x
+      - uses: goreleaser/goreleaser-action@v2
+        with:
+          version: latest
+          args: release --rm-dist
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,6 +2,7 @@ name: goreleaser
 
 on:
   push:
+    tags: ["*"]
 
 jobs:
   goreleaser:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,7 +12,7 @@ jobs:
         run: git fetch --prune --unshallow
       - uses: actions/setup-go@v1
         with:
-          go-version: 1.16.x
+          go-version: 1.17.x
       - uses: goreleaser/goreleaser-action@v2
         with:
           version: latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,7 +2,6 @@ name: goreleaser
 
 on:
   push:
-    tags: ["*"]
 
 jobs:
   goreleaser:

--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ bazel*
 docker-credential-gcr
 .idea
 *.iml
+dist/

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,0 +1,32 @@
+# This is an example .goreleaser.yml file with some sane defaults.
+# Make sure to check the documentation at http://goreleaser.com
+before:
+  hooks:
+    # You may remove this if you don't use go modules.
+    - go mod tidy
+    # you may remove this if you don't need go generate
+    - go generate ./...
+builds:
+  - env:
+      - CGO_ENABLED=0
+    goos:
+      - linux
+      - windows
+      - darwin
+archives:
+  - replacements:
+      darwin: Darwin
+      linux: Linux
+      windows: Windows
+      386: i386
+      amd64: x86_64
+checksum:
+  name_template: 'checksums.txt'
+snapshot:
+  name_template: "{{ incpatch .Tag }}-next"
+changelog:
+  sort: asc
+  filters:
+    exclude:
+      - '^docs:'
+      - '^test:'

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -18,17 +18,11 @@ builds:
       - windows
       - darwin
 archives:
-  - replacements:
-      darwin: Darwin
-      linux: Linux
-      windows: Windows
-      386: i386
-      amd64: x86_64
-    name_template: "{{ .ProjectName }}_{{ .Os }}_{{ .Arch }}-{{ .Version }}"
+  - name_template: "{{ .ProjectName }}_{{ .Os }}_{{ .Arch }}-{{ .Version }}"
 checksum:
   name_template: "checksums.txt"
 snapshot:
-  name_template: "{{ incpatch .Tag }}"
+  name_template: "{{ .Tag }}"
 changelog:
   sort: asc
   filters:

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -2,13 +2,17 @@
 # Make sure to check the documentation at http://goreleaser.com
 before:
   hooks:
-    # You may remove this if you don't use go modules.
+    # Needed because we use go modules.
     - go mod tidy
-    # you may remove this if you don't need go generate
-    - go generate ./...
 builds:
   - env:
       - CGO_ENABLED=0
+    ldflags:
+      - "-s -w -X github.com/GoogleCloudPlatform/docker-credential-gcr/config.Version={{.Version}}"
+    goarch:
+      - amd64
+      - arm64
+      - 386
     goos:
       - linux
       - windows
@@ -20,13 +24,14 @@ archives:
       windows: Windows
       386: i386
       amd64: x86_64
+    name_template: "{{ .ProjectName }}_{{ .Os }}_{{ .Arch }}-{{ .Version }}"
 checksum:
-  name_template: 'checksums.txt'
+  name_template: "checksums.txt"
 snapshot:
-  name_template: "{{ incpatch .Tag }}-next"
+  name_template: "{{ incpatch .Tag }}"
 changelog:
   sort: asc
   filters:
     exclude:
-      - '^docs:'
-      - '^test:'
+      - "^docs:"
+      - "^test:"

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -22,7 +22,7 @@ archives:
 checksum:
   name_template: "checksums.txt"
 snapshot:
-  name_template: "{{ .Tag }}"
+  name_template: "{{ .Version }}"
 changelog:
   sort: asc
   filters:

--- a/cli/version.go
+++ b/cli/version.go
@@ -40,6 +40,6 @@ func NewVersionSubcommand() subcommands.Command {
 }
 
 func (p *versionCmd) Execute(context.Context, *flag.FlagSet, ...interface{}) subcommands.ExitStatus {
-	fmt.Fprintf(os.Stdout, "Google Container Registry Docker credential helper %d.%d.%d\n", config.MajorVersion, config.MinorVersion, config.PatchVersion)
+	fmt.Fprintf(os.Stdout, "Google Container Registry Docker credential helper %s\n", config.Version)
 	return subcommands.ExitSuccess
 }

--- a/config/const.go
+++ b/config/const.go
@@ -19,6 +19,7 @@ import (
 	"context"
 	"fmt"
 	"runtime/debug"
+	"strings"
 
 	"golang.org/x/oauth2/google"
 )
@@ -115,4 +116,4 @@ var GCRScopes = []string{"https://www.googleapis.com/auth/cloud-platform"}
 var OAuthHTTPContext = context.Background()
 
 // GcrOAuth2Username is the Basic auth username accompanying Docker requests to GCR.
-var GcrOAuth2Username = fmt.Sprintf("_dcgcr_%s_token", Version)
+var GcrOAuth2Username = fmt.Sprintf("_dcgcr_%s_token", strings.ReplaceAll(Version, ".", "_"))

--- a/config/const.go
+++ b/config/const.go
@@ -18,6 +18,7 @@ package config
 import (
 	"context"
 	"fmt"
+	"runtime/debug"
 
 	"golang.org/x/oauth2/google"
 )
@@ -32,19 +33,21 @@ const (
 	// performing the OAuth2 Authorization Code grant flow.
 	// See https://developers.google.com/identity/protocols/OAuth2InstalledApp
 	GCRCredHelperClientNotSoSecret = "HpVi8cnKx8AAkddzaNrSWmS8"
-
-	// From http://semver.org/
-	// MAJOR version when you make incompatible API changes,
-	// MINOR version when you add functionality in a backwards-compatible manner, and
-	// PATCH version when you make backwards-compatible bug fixes.
-
-	// MajorVersion is the credential helper's major version number.
-	MajorVersion = 2
-	// MinorVersion is the credential helper's minor version number.
-	MinorVersion = 0
-	// PatchVersion is the credential helper's patch version number.
-	PatchVersion = 4
 )
+
+// Version can be set via:
+// -ldflags="-X 'github.com/GoogleCloudPlatform/docker-credential-gcr/config.Version=$TAG'"
+var Version string
+
+func init() {
+	if Version == "" {
+		i, ok := debug.ReadBuildInfo()
+		if !ok {
+			return
+		}
+		Version = i.Main.Version
+	}
+}
 
 // DefaultGCRRegistries contains the list of default registries to authenticate for.
 var DefaultGCRRegistries = [...]string{
@@ -112,4 +115,4 @@ var GCRScopes = []string{"https://www.googleapis.com/auth/cloud-platform"}
 var OAuthHTTPContext = context.Background()
 
 // GcrOAuth2Username is the Basic auth username accompanying Docker requests to GCR.
-var GcrOAuth2Username = fmt.Sprintf("_dcgcr_%d_%d_%d_token", MajorVersion, MinorVersion, PatchVersion)
+var GcrOAuth2Username = fmt.Sprintf("_dcgcr_%s_token", Version)

--- a/credhelper/helper_unit_test.go
+++ b/credhelper/helper_unit_test.go
@@ -29,7 +29,7 @@ import (
 	"github.com/golang/mock/gomock"
 )
 
-var expectedGCRUsername = fmt.Sprintf("_dcgcr_%d_%d_%d_token", config.MajorVersion, config.MinorVersion, config.PatchVersion)
+var expectedGCRUsername = fmt.Sprintf("_dcgcr_%s_token", config.Version)
 
 var testGCRHosts = [...]string{
 	"gcr.io",

--- a/test/e2e_test.go
+++ b/test/e2e_test.go
@@ -1,3 +1,4 @@
+//go:build !unit && !gazelle
 // +build !unit,!gazelle
 
 // Copyright 2016 Google, Inc.
@@ -123,7 +124,11 @@ func TestEndToEnd_GCRCreds(t *testing.T) {
 	}
 
 	if match, err := regexp.MatchString("_dcgcr_(?:[0-9]+_)*token", creds.Username); !match || err != nil {
-		t.Errorf("Bad GCR username: Wanted: %q, Got (val, err): %q, %v", "_dcgcr_(?:[0-9]+_)*token", creds.Username, err)
+		// Fail if not a dev version.
+		devUsername := "_dcgcr__token"
+		if creds.Username != devUsername {
+			t.Errorf("Bad GCR username: Wanted: %q, Got (val, err): %q, %v", "_dcgcr_(?:[0-9]+_)*token", creds.Username, err)
+		}
 	}
 	if creds.Secret != gcrAccessToken {
 		t.Errorf("Bad GCR access token. Wanted: %s, Got: %s", gcrAccessToken, creds.Secret)

--- a/test/version_test.go
+++ b/test/version_test.go
@@ -1,3 +1,4 @@
+//go:build !unit && !gazelle
 // +build !unit,!gazelle
 
 // Copyright 2016 Google, Inc.
@@ -32,9 +33,13 @@ func TestVersion(t *testing.T) {
 	}
 
 	// Enforce a particular format so that a regex can extract the version easily.
-	expectedRegex := "Google Container Registry Docker credential helper [0-9]+\\.[0-9]+\\.[0-9]+\n"
 	actual := out.String()
-	if match, _ := regexp.MatchString(expectedRegex, actual); !match {
-		t.Fatalf("Expected version string to match: %s, got: %s", expectedRegex, actual)
+	expectedProdRegex := "Google Container Registry Docker credential helper [0-9]+\\_[0-9]+\\_[0-9]+\n"
+	if match, _ := regexp.MatchString(expectedProdRegex, actual); !match {
+		// Fail if not a dev version.
+		expectedDevString := "Google Container Registry Docker credential helper (devel)\n"
+		if actual != expectedDevString {
+			t.Fatalf("Expected version string to match: %s, got: %s", expectedProdRegex, actual)
+		}
 	}
 }


### PR DESCRIPTION
This PR adds a github action to automatically release on tags using goreleaser. It also removes the Major/Minor/Patch Version variables from `config/const.go` and sets one `Version` variable with ldflags (fixing issue #87).

I verified this github action [on my branch](https://github.com/rafibarash/docker-credential-gcr/runs/3561565004?check_suite_focus=true).