### PR TITLE
Add s390x support in goreleaser config file

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -13,6 +13,7 @@ builds:
       - amd64
       - arm64
       - 386
+      - s390x
     goos:
       - linux
       - windows


### PR DESCRIPTION
This PR is to add s390x support in `goreleaser` config file so that it will build and release  binaries for linux/s390x platform as well.

Signed-off-by: Kun-Lu <kun.lu@ibm.com>