### PR TITLE
Change OAuth2 scope to be more restrictive

### DIFF
--- a/auth/login_integration_test.go
+++ b/auth/login_integration_test.go
@@ -37,7 +37,7 @@ import (
 const (
 	// The client ID corresponding to GCR's OAuth2 login page.
 	expectedClientID  = "99426463878-o7n0bshgue20tdpm25q4at0vs2mr4utq.apps.googleusercontent.com"
-	expectedScope     = "https://www.googleapis.com/auth/cloud-platform"
+	expectedScope     = "https://www.googleapis.com/auth/devstorage.read_write"
 	expectedHost      = "localhost"
 	expectedAuthPath  = "/auth"
 	expectedTokenPath = "/token"

--- a/config/const.go
+++ b/config/const.go
@@ -116,7 +116,7 @@ var SupportedGCRTokenSources = map[string]string{
 var GCROAuth2Endpoint = google.Endpoint
 
 // GCRScopes is/are the OAuth2 scope(s) to request during access_token creation.
-var GCRScopes = []string{"https://www.googleapis.com/auth/cloud-platform"}
+var GCRScopes = []string{"https://www.googleapis.com/auth/devstorage.read_write"}
 
 // OAuthHTTPContext is the HTTP context to use when performing OAuth2 calls.
 var OAuthHTTPContext = context.Background()


### PR DESCRIPTION
Change the OAuth scope from cloud-platform to devstorage.read_write which is enough for pushing/pulling docker images but more restrictive than cloud-platform scope.