### PR TITLE
Require a valid oauth2 username

### DIFF
--- a/config/const.go
+++ b/config/const.go
@@ -18,6 +18,7 @@ package config
 import (
 	"context"
 	"fmt"
+	"regexp"
 	"runtime/debug"
 	"strings"
 
@@ -124,4 +125,13 @@ var GCRScopes = []string{"https://www.googleapis.com/auth/devstorage.read_write"
 var OAuthHTTPContext = context.Background()
 
 // GcrOAuth2Username is the Basic auth username accompanying Docker requests to GCR.
-var GcrOAuth2Username = fmt.Sprintf("_dcgcr_%s_token", strings.ReplaceAll(Version, ".", "_"))
+var GcrOAuth2Username string
+
+func init() {
+	re := regexp.MustCompile(`^(?:[0-9]+\._)*$`)
+	if re.MatchString(Version) {
+		GcrOAuth2Username = fmt.Sprintf("_dcgcr_%s_token", strings.ReplaceAll(Version, ".", "_"))
+	} else {
+		GcrOAuth2Username = "_dcgcr_0_0_0_token"
+	}
+}


### PR DESCRIPTION
Fixes #135.

This validates the regexp of the version according to https://github.com/GoogleCloudPlatform/docker-credential-gcr/issues/129#issuecomment-1490603238, and if it's not valid, it falls back to a 0 value.