### PR TITLE
Update go mod references for v2

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -19,7 +19,7 @@ gazelle(
 go_library(
     name = "go_default_library",
     srcs = ["main.go"],
-    importpath = "github.com/GoogleCloudPlatform/docker-credential-gcr",
+    importpath = "github.com/GoogleCloudPlatform/docker-credential-gcr/v2",
     visibility = ["//visibility:private"],
     deps = [
         "//cli:go_default_library",

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ The program in this repository is written with the Go programming language and c
 You can download the source code, compile the binary, and put it in your `$GOPATH` with `go get`.
 
 ```shell
-go get -u github.com/GoogleCloudPlatform/docker-credential-gcr
+go get -u github.com/GoogleCloudPlatform/docker-credential-gcr/v2
 ```
 
 If `$GOPATH/bin` is in your system `$PATH`, this will also automatically install the compiled binary. You can confirm using `which docker-credential-gcr` and continue to the [section on Configuration and Usage](#configuration-and-usage).

--- a/auth/BUILD
+++ b/auth/BUILD
@@ -3,7 +3,7 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 go_library(
     name = "go_default_library",
     srcs = ["login.go"],
-    importpath = "github.com/GoogleCloudPlatform/docker-credential-gcr/auth",
+    importpath = "github.com/GoogleCloudPlatform/docker-credential-gcr/v2/auth",
     visibility = ["//visibility:public"],
     deps = [
         "//config:go_default_library",

--- a/auth/login.go
+++ b/auth/login.go
@@ -31,7 +31,7 @@ import (
 	"os"
 	"strings"
 
-	"github.com/GoogleCloudPlatform/docker-credential-gcr/config"
+	"github.com/GoogleCloudPlatform/docker-credential-gcr/v2/config"
 	"github.com/toqueteos/webbrowser"
 	"golang.org/x/oauth2"
 )

--- a/auth/login_integration_test.go
+++ b/auth/login_integration_test.go
@@ -29,7 +29,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/GoogleCloudPlatform/docker-credential-gcr/config"
+	"github.com/GoogleCloudPlatform/docker-credential-gcr/v2/config"
 	"golang.org/x/oauth2"
 	"golang.org/x/sync/errgroup"
 )

--- a/cli/BUILD
+++ b/cli/BUILD
@@ -12,7 +12,7 @@ go_library(
         "gcr-logout.go",
         "version.go",
     ],
-    importpath = "github.com/GoogleCloudPlatform/docker-credential-gcr/cli",
+    importpath = "github.com/GoogleCloudPlatform/docker-credential-gcr/v2/cli",
     visibility = ["//visibility:public"],
     deps = [
         "//auth:go_default_library",

--- a/cli/clear.go
+++ b/cli/clear.go
@@ -20,7 +20,7 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/GoogleCloudPlatform/docker-credential-gcr/store"
+	"github.com/GoogleCloudPlatform/docker-credential-gcr/v2/store"
 	"github.com/google/subcommands"
 )
 

--- a/cli/config.go
+++ b/cli/config.go
@@ -22,7 +22,7 @@ import (
 	"os"
 	"strings"
 
-	"github.com/GoogleCloudPlatform/docker-credential-gcr/config"
+	"github.com/GoogleCloudPlatform/docker-credential-gcr/v2/config"
 	"github.com/google/subcommands"
 )
 

--- a/cli/configure-docker.go
+++ b/cli/configure-docker.go
@@ -24,7 +24,7 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/GoogleCloudPlatform/docker-credential-gcr/config"
+	"github.com/GoogleCloudPlatform/docker-credential-gcr/v2/config"
 	cliconfig "github.com/docker/cli/cli/config"
 	"github.com/docker/cli/cli/config/configfile"
 	"github.com/google/subcommands"

--- a/cli/dockerHelper.go
+++ b/cli/dockerHelper.go
@@ -20,9 +20,9 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/GoogleCloudPlatform/docker-credential-gcr/config"
-	"github.com/GoogleCloudPlatform/docker-credential-gcr/credhelper"
-	"github.com/GoogleCloudPlatform/docker-credential-gcr/store"
+	"github.com/GoogleCloudPlatform/docker-credential-gcr/v2/config"
+	"github.com/GoogleCloudPlatform/docker-credential-gcr/v2/credhelper"
+	"github.com/GoogleCloudPlatform/docker-credential-gcr/v2/store"
 	"github.com/docker/docker-credential-helpers/credentials"
 	"github.com/google/subcommands"
 )

--- a/cli/gcr-login.go
+++ b/cli/gcr-login.go
@@ -20,8 +20,8 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/GoogleCloudPlatform/docker-credential-gcr/auth"
-	"github.com/GoogleCloudPlatform/docker-credential-gcr/store"
+	"github.com/GoogleCloudPlatform/docker-credential-gcr/v2/auth"
+	"github.com/GoogleCloudPlatform/docker-credential-gcr/v2/store"
 	"github.com/google/subcommands"
 )
 

--- a/cli/gcr-logout.go
+++ b/cli/gcr-logout.go
@@ -20,7 +20,7 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/GoogleCloudPlatform/docker-credential-gcr/store"
+	"github.com/GoogleCloudPlatform/docker-credential-gcr/v2/store"
 	"github.com/google/subcommands"
 )
 

--- a/cli/version.go
+++ b/cli/version.go
@@ -20,7 +20,7 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/GoogleCloudPlatform/docker-credential-gcr/config"
+	"github.com/GoogleCloudPlatform/docker-credential-gcr/v2/config"
 	"github.com/google/subcommands"
 )
 

--- a/config/BUILD
+++ b/config/BUILD
@@ -6,7 +6,7 @@ go_library(
         "const.go",
         "file.go",
     ],
-    importpath = "github.com/GoogleCloudPlatform/docker-credential-gcr/config",
+    importpath = "github.com/GoogleCloudPlatform/docker-credential-gcr/v2/config",
     visibility = ["//visibility:public"],
     deps = [
         "//util:go_default_library",

--- a/config/const.go
+++ b/config/const.go
@@ -37,7 +37,7 @@ const (
 )
 
 // Version can be set via:
-// -ldflags="-X 'github.com/GoogleCloudPlatform/docker-credential-gcr/config.Version=$TAG'"
+// -ldflags="-X 'github.com/GoogleCloudPlatform/docker-credential-gcr/v2/config.Version=$TAG'"
 var Version string
 
 func init() {

--- a/config/file.go
+++ b/config/file.go
@@ -21,7 +21,7 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/GoogleCloudPlatform/docker-credential-gcr/util"
+	"github.com/GoogleCloudPlatform/docker-credential-gcr/v2/util"
 )
 
 const (

--- a/credhelper/BUILD
+++ b/credhelper/BUILD
@@ -3,7 +3,7 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 go_library(
     name = "go_default_library",
     srcs = ["helper.go"],
-    importpath = "github.com/GoogleCloudPlatform/docker-credential-gcr/credhelper",
+    importpath = "github.com/GoogleCloudPlatform/docker-credential-gcr/v2/credhelper",
     visibility = ["//visibility:public"],
     deps = [
         "//config:go_default_library",

--- a/credhelper/helper.go
+++ b/credhelper/helper.go
@@ -23,9 +23,9 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/GoogleCloudPlatform/docker-credential-gcr/config"
-	"github.com/GoogleCloudPlatform/docker-credential-gcr/store"
-	"github.com/GoogleCloudPlatform/docker-credential-gcr/util/cmd"
+	"github.com/GoogleCloudPlatform/docker-credential-gcr/v2/config"
+	"github.com/GoogleCloudPlatform/docker-credential-gcr/v2/store"
+	"github.com/GoogleCloudPlatform/docker-credential-gcr/v2/util/cmd"
 	"github.com/docker/docker-credential-helpers/credentials"
 
 	"golang.org/x/oauth2/google"

--- a/credhelper/helper_unit_test.go
+++ b/credhelper/helper_unit_test.go
@@ -19,13 +19,13 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/GoogleCloudPlatform/docker-credential-gcr/mock/mock_cmd"
-	"github.com/GoogleCloudPlatform/docker-credential-gcr/mock/mock_config" // mocks must be generated before test execution
-	"github.com/GoogleCloudPlatform/docker-credential-gcr/mock/mock_store"
+	"github.com/GoogleCloudPlatform/docker-credential-gcr/v2/mock/mock_cmd"
+	"github.com/GoogleCloudPlatform/docker-credential-gcr/v2/mock/mock_config" // mocks must be generated before test execution
+	"github.com/GoogleCloudPlatform/docker-credential-gcr/v2/mock/mock_store"
 
-	"github.com/GoogleCloudPlatform/docker-credential-gcr/config"
-	"github.com/GoogleCloudPlatform/docker-credential-gcr/store"
-	"github.com/GoogleCloudPlatform/docker-credential-gcr/util/cmd"
+	"github.com/GoogleCloudPlatform/docker-credential-gcr/v2/config"
+	"github.com/GoogleCloudPlatform/docker-credential-gcr/v2/store"
+	"github.com/GoogleCloudPlatform/docker-credential-gcr/v2/util/cmd"
 	"github.com/golang/mock/gomock"
 )
 

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/GoogleCloudPlatform/docker-credential-gcr
+module github.com/GoogleCloudPlatform/docker-credential-gcr/v2
 
 go 1.17
 

--- a/main.go
+++ b/main.go
@@ -25,7 +25,7 @@ import (
 	"flag"
 	"os"
 
-	"github.com/GoogleCloudPlatform/docker-credential-gcr/cli"
+	"github.com/GoogleCloudPlatform/docker-credential-gcr/v2/cli"
 	"github.com/google/subcommands"
 )
 

--- a/mock/mock_cmd/BUILD
+++ b/mock/mock_cmd/BUILD
@@ -3,7 +3,7 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library")
 go_library(
     name = "go_default_library",
     srcs = ["mocks.go"],
-    importpath = "github.com/GoogleCloudPlatform/docker-credential-gcr/mock/mock_cmd",
+    importpath = "github.com/GoogleCloudPlatform/docker-credential-gcr/v2/mock/mock_cmd",
     visibility = ["//visibility:public"],
     deps = ["//vendor/github.com/golang/mock/gomock:go_default_library"],
 )

--- a/mock/mock_config/BUILD
+++ b/mock/mock_config/BUILD
@@ -3,7 +3,7 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library")
 go_library(
     name = "go_default_library",
     srcs = ["mocks.go"],
-    importpath = "github.com/GoogleCloudPlatform/docker-credential-gcr/mock/mock_config",
+    importpath = "github.com/GoogleCloudPlatform/docker-credential-gcr/v2/mock/mock_config",
     visibility = ["//visibility:public"],
     deps = ["//vendor/github.com/golang/mock/gomock:go_default_library"],
 )

--- a/mock/mock_store/BUILD
+++ b/mock/mock_store/BUILD
@@ -3,7 +3,7 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library")
 go_library(
     name = "go_default_library",
     srcs = ["mocks.go"],
-    importpath = "github.com/GoogleCloudPlatform/docker-credential-gcr/mock/mock_store",
+    importpath = "github.com/GoogleCloudPlatform/docker-credential-gcr/v2/mock/mock_store",
     visibility = ["//visibility:public"],
     deps = [
         "//store:go_default_library",

--- a/mock/mock_store/mocks.go
+++ b/mock/mock_store/mocks.go
@@ -5,7 +5,7 @@
 package mock_store
 
 import (
-	store "github.com/GoogleCloudPlatform/docker-credential-gcr/store"
+	store "github.com/GoogleCloudPlatform/docker-credential-gcr/v2/store"
 	credentials "github.com/docker/docker-credential-helpers/credentials"
 	gomock "github.com/golang/mock/gomock"
 	oauth2 "golang.org/x/oauth2"

--- a/store/BUILD
+++ b/store/BUILD
@@ -3,7 +3,7 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 go_library(
     name = "go_default_library",
     srcs = ["store.go"],
-    importpath = "github.com/GoogleCloudPlatform/docker-credential-gcr/store",
+    importpath = "github.com/GoogleCloudPlatform/docker-credential-gcr/v2/store",
     visibility = ["//visibility:public"],
     deps = [
         "//config:go_default_library",

--- a/store/store.go
+++ b/store/store.go
@@ -28,8 +28,8 @@ import (
 	"strings"
 	"time"
 
-	"github.com/GoogleCloudPlatform/docker-credential-gcr/config"
-	"github.com/GoogleCloudPlatform/docker-credential-gcr/util"
+	"github.com/GoogleCloudPlatform/docker-credential-gcr/v2/config"
+	"github.com/GoogleCloudPlatform/docker-credential-gcr/v2/util"
 	"github.com/docker/docker-credential-helpers/credentials"
 	"golang.org/x/oauth2"
 	"golang.org/x/oauth2/google"

--- a/test/BUILD
+++ b/test/BUILD
@@ -7,6 +7,6 @@ go_library(
         "const.go",
         "util.go",
     ],
-    importpath = "github.com/GoogleCloudPlatform/docker-credential-gcr/test",
+    importpath = "github.com/GoogleCloudPlatform/docker-credential-gcr/v2/test",
     visibility = ["//visibility:public"],
 )

--- a/test/config_test.go
+++ b/test/config_test.go
@@ -26,7 +26,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/GoogleCloudPlatform/docker-credential-gcr/config"
+	"github.com/GoogleCloudPlatform/docker-credential-gcr/v2/config"
 	cliconfig "github.com/docker/cli/cli/config"
 	"github.com/docker/cli/cli/config/configfile"
 )

--- a/util/BUILD
+++ b/util/BUILD
@@ -3,6 +3,6 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library")
 go_library(
     name = "go_default_library",
     srcs = ["util.go"],
-    importpath = "github.com/GoogleCloudPlatform/docker-credential-gcr/util",
+    importpath = "github.com/GoogleCloudPlatform/docker-credential-gcr/v2/util",
     visibility = ["//visibility:public"],
 )

--- a/util/cmd/BUILD
+++ b/util/cmd/BUILD
@@ -3,6 +3,6 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library")
 go_library(
     name = "go_default_library",
     srcs = ["exec.go"],
-    importpath = "github.com/GoogleCloudPlatform/docker-credential-gcr/util/cmd",
+    importpath = "github.com/GoogleCloudPlatform/docker-credential-gcr/v2/util/cmd",
     visibility = ["//visibility:public"],
 )


### PR DESCRIPTION
Fixes #128

I believe this updates all the module references to properly handle the v2 tags in Go itself. There are some bits in bazel and and the automatically generated mocking code that I didn't touch since I'm not familiar with them. A new release will be needed to fully fix #128.