### PR TITLE
Fix for version handling

### DIFF
--- a/config/const.go
+++ b/config/const.go
@@ -43,11 +43,16 @@ var Version string
 
 func init() {
 	if Version == "" {
-		i, ok := debug.ReadBuildInfo()
-		if !ok {
-			return
+		if i, ok := debug.ReadBuildInfo(); ok {
+			Version = i.Main.Version
 		}
-		Version = i.Main.Version
+	}
+	Version = strings.TrimPrefix(Version, "v")
+	re := regexp.MustCompile(`^[0-9]+(?:[\._][0-9]+)*$`)
+	if re.MatchString(Version) {
+		GcrOAuth2Username = fmt.Sprintf("_dcgcr_%s_token", strings.ReplaceAll(Version, ".", "_"))
+	} else {
+		GcrOAuth2Username = "_dcgcr_0_0_0_token"
 	}
 }
 
@@ -127,12 +132,3 @@ var OAuthHTTPContext = context.Background()
 
 // GcrOAuth2Username is the Basic auth username accompanying Docker requests to GCR.
 var GcrOAuth2Username string
-
-func init() {
-	re := regexp.MustCompile(`^(?:[0-9]+\._)*$`)
-	if re.MatchString(Version) {
-		GcrOAuth2Username = fmt.Sprintf("_dcgcr_%s_token", strings.ReplaceAll(Version, ".", "_"))
-	} else {
-		GcrOAuth2Username = "_dcgcr_0_0_0_token"
-	}
-}

--- a/credhelper/helper_unit_test.go
+++ b/credhelper/helper_unit_test.go
@@ -17,6 +17,7 @@ package credhelper
 import (
 	"errors"
 	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/GoogleCloudPlatform/docker-credential-gcr/v2/mock/mock_cmd"
@@ -29,7 +30,8 @@ import (
 	"github.com/golang/mock/gomock"
 )
 
-var expectedGCRUsername = fmt.Sprintf("_dcgcr_%s_token", config.Version)
+var expectedGCRUsername = fmt.Sprintf("_dcgcr_%s_token", strings.ReplaceAll(config.Version, ".", "_"))
+var expectedGCRZeroUsername = "_dcgcr_0_0_0_token"
 
 var testGCRHosts = [...]string{
 	"gcr.io",
@@ -72,7 +74,7 @@ func TestGet_GCRCredentials(t *testing.T) {
 		username, secret, err := tested.Get("https://" + host)
 		if err != nil {
 			t.Errorf("get returned an error: %v", err)
-		} else if username != expectedGCRUsername {
+		} else if username != expectedGCRUsername && username != expectedGCRZeroUsername {
 			t.Errorf("expected GCR username: %s but got: %s", expectedGCRUsername, username)
 		} else if secret != expectedSecret {
 			t.Errorf("expected secret: %s but got: %s", expectedSecret, secret)


### PR DESCRIPTION
The regex for checking if the version string is valid is unfortunately broken, so it falls back to the zero value in the token user. And if the image is built from a `go install` command, the version will have a "v" prefix that needs to be removed.
