### PR TITLE
Bump to go 1.21

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,7 +5,7 @@ jobs:
   test:
     strategy:
       matrix:
-        go-version: [1.19, 1.x] # Test 1.19 and tip
+        go-version: [1.21, 1.x] # Test 1.21 and tip
         os: [ubuntu-latest, macos-latest, windows-latest]
     runs-on: ${{ matrix.os }}
     steps:

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/GoogleCloudPlatform/docker-credential-gcr/v2
 
-go 1.19
+go 1.21
 
 require (
 	github.com/docker/cli v24.0.5+incompatible


### PR DESCRIPTION
Some CVEs need newer go versions to be resolved. 