### PR TITLE
Fix go releaser github action and add building test to catch issues before merging.

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,9 +17,7 @@ jobs:
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v6
         with:
-          # either 'goreleaser' (default) or 'goreleaser-pro'
           distribution: goreleaser
-          # 'latest', 'nightly', or a semver
           version: '~> v2'
           args: release --clean
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,15 +8,19 @@ jobs:
   goreleaser:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - name: Unshallow
-        run: git fetch --prune --unshallow
-      - uses: actions/setup-go@v1
+      - name: Checkout
+        uses: actions/checkout@v4
         with:
-          go-version: 1.21.x
-      - uses: goreleaser/goreleaser-action@v2
+          fetch-depth: 0
+      - name: Set up Go
+        uses: actions/setup-go@v5
+      - name: Run GoReleaser
+        uses: goreleaser/goreleaser-action@v6
         with:
-          version: latest
-          args: release --rm-dist
+          # either 'goreleaser' (default) or 'goreleaser-pro'
+          distribution: goreleaser
+          # 'latest', 'nightly', or a semver
+          version: '~> v2'
+          args: release --clean
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,7 +2,7 @@ on: [push, pull_request]
 name: Test
 
 jobs:
-  test:
+  go-test:
     strategy:
       matrix:
         go-version: [1.21, 1.x] # Test 1.21 and tip
@@ -34,3 +34,16 @@ jobs:
         run: |
           go test -timeout 10s -v -tags=windows ./...
           go test -race -timeout 10s -v -tags=windows ./...
+  goreleaser-test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set up Go
+        uses: actions/setup-go@v5
+      - name: Build GoReleaser
+        uses: goreleaser/goreleaser-action@v6
+        with:
+          distribution: goreleaser
+          version: '~> v2'
+          args: build
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -48,6 +48,6 @@ jobs:
         with:
           distribution: goreleaser
           version: '~> v2'
-          args: build
+          args: build --snapshot --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -37,6 +37,10 @@ jobs:
   goreleaser-test:
     runs-on: ubuntu-latest
     steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - name: Set up Go
         uses: actions/setup-go@v5
       - name: Build GoReleaser


### PR DESCRIPTION
Fixes #165

This action [failed](https://github.com/GoogleCloudPlatform/docker-credential-gcr/actions/runs/10065542841/job/27824896147) for the last release.

Updating based on the github marketplace [docs](https://github.com/GoogleCloudPlatform/docker-credential-gcr/actions/runs/10065542841/job/27824896147)