### PR TITLE
ci: fix version output in `version` subcommand (release binaries)

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -9,7 +9,7 @@ builds:
   - env:
       - CGO_ENABLED=0
     ldflags:
-      - "-s -w -X github.com/GoogleCloudPlatform/docker-credential-gcr/config.Version={{.Version}}"
+      - "-s -w -X github.com/GoogleCloudPlatform/docker-credential-gcr/v2/config.Version={{.Version}}"
     goarch:
       - amd64
       - arm64


### PR DESCRIPTION
Fixes #155 

I noticed that `docker-credential-gcr version` does not print the correct version when downloaded from the release assets:

```
~ ✗ docker-credential-gcr version
Google Container Registry Docker credential helper (devel)
```

In our case, this breaks idempotent installs in CI, because we can not detect any previously installed versions properly.
Having to install `go` first to be able to install `docker-credential-gcr` would also waste valuable build time.

Looking through the code I noticed that the `goreleaser.yaml` config wasn't using the exact `ldflags` that is mentioned in [config/const.go](https://github.com/GoogleCloudPlatform/docker-credential-gcr/blob/master/config/const.go#L41). The config essentially references the wrong package.