### PR TITLE
Grant goreleaser workflow permissions to create releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,6 +7,8 @@ on:
 jobs:
   goreleaser:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
Fixes #178

Actions were locked down at the org level to read-only. But we should be able to add this on a job-specific basis. Found a similar PR in https://github.com/GoogleCloudPlatform/marketplace-tools/pull/91