### PR TITLE
Upgrade Go version to 1.26

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,8 @@
 module github.com/GoogleCloudPlatform/docker-credential-gcr/v2
 
-go 1.23.0
+go 1.26.0
 
-toolchain go1.23.2
+toolchain go1.26.4
 
 require (
 	cloud.google.com/go/auth v0.16.2


### PR DESCRIPTION
Upgrade Go version to 1.26.0 and toolchain to 1.26.4.

TAG=agy
CONV=fb268476-f9d2-436f-9f9b-25556af906f8